### PR TITLE
Fix label lookup

### DIFF
--- a/k8s-mermaid.py
+++ b/k8s-mermaid.py
@@ -21,6 +21,7 @@ def parse_kubernetes_resources(yaml_file):
                     'api_version': api_version,
                     'name': name,
                     'namespace': namespace,
+                    'labels': labels,
                     'service_account_name': None,
                     'image': None,
                     'ports': [],


### PR DESCRIPTION
## Summary
- keep resource labels in parse_kubernetes_resources

## Testing
- `python3 -m py_compile k8s-mermaid.py`

------
https://chatgpt.com/codex/tasks/task_e_68433f57b44483328f545ded43f00d24